### PR TITLE
adding go course links

### DIFF
--- a/Go/courses.md
+++ b/Go/courses.md
@@ -1,1 +1,6 @@
 # Useful Tutorial courses for Go
+
+play-with-go.dev "A series of hands-on, interactive, browser-based guides that introduce the tools required to work with the Go programming language."
+
+https://www.calhoun.io/courses Courses created by Jon Calhoun for learning different aspects of go.
+

--- a/Go/info.json
+++ b/Go/info.json
@@ -1,6 +1,12 @@
 {
-    "creators": {
-        "title": "Sina Yeganeh Faal",
-        "link": "https://github.com/SinaYeganeh0-0"
-    }
+    "creators": [
+        {
+            "title": "Sina Yeganeh Faal",
+            "link": "https://github.com/SinaYeganeh0-0"
+        },
+        {
+            "title": "Jen Dunlap",
+            "link": "https://github.com/jdun28"
+        }
+    ]
 }

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,7 @@
 | [🌐 Pine-Script](/Pine-Script) |✅ Done! | ✅ Done! | [ℹ️ Add one!](/Pine-Script/courses.md) | [ℹ️ Add one!](/Pine-Script/resources.md) | 
 | [🌐 Oz](/Oz) |✅ Done! | [ℹ️ Add one!](/Oz/books.md) | [ℹ️ Add one!](/Oz/courses.md) | ✅ Done! | 
 | [🌐 Kotlin](/Kotlin) |✅ Done! | ✅ Done! | [ℹ️ Add one!](/Kotlin/courses.md) | [ℹ️ Add one!](/Kotlin/resources.md) | 
-| [🌐 Go](/Go) |✅ Done! | ✅ Done! | [ℹ️ Add one!](/Go/courses.md) | [ℹ️ Add one!](/Go/resources.md) | 
+| [🌐 Go](/Go) |✅ Done! | ✅ Done! | ✅ Done! | [ℹ️ Add one!](/Go/resources.md) | 
 | [🌐 Fastapi](/Fastapi) |✅ Done! | [ℹ️ Add one!](/Fastapi/books.md) | ✅ Done! | [ℹ️ Add one!](/Fastapi/resources.md) | 
 | [🌐 Arduino](/Arduino) |✅ Done! | ✅ Done! | [ℹ️ Add one!](/Arduino/courses.md) | [ℹ️ Add one!](/Arduino/resources.md) | 
 | [🌐 فردوسی](/فردوسی) |✅ Done! | [ℹ️ Add one!](/فردوسی/books.md) | [ℹ️ Add one!](/فردوسی/courses.md) | [ℹ️ Add one!](/فردوسی/resources.md) | 


### PR DESCRIPTION
Adds links to two helpful websites for courses for learning go, also updates creators in the `go/info.json` to be an array/adds myself as a creator for contributing.